### PR TITLE
[#8] PersonalSchedulePage 페이지 + 컴포넌트 [Header, PersonalTodoList, Modal] 생성

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,26 @@
       href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
       rel="stylesheet"
     />
-    <script type="text/javascript" src="https://static.nid.naver.com/js/naveridlogin_js_sdk_2.0.0.js" charset="utf-8"></script>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.0/css/all.min.css"
+    />
+
+    <script
+      type="text/javascript"
+      src="https://static.nid.naver.com/js/naveridlogin_js_sdk_2.0.0.js"
+      charset="utf-8"
+    ></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>xERN</title>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,14 @@
       "name": "00-xern-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@emotion/react": "^11.10.6",
+        "@emotion/styled": "^11.10.6",
         "@react-oauth/google": "^0.9.0",
         "@reduxjs/toolkit": "^1.9.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.8.0",
+        "react-modal": "^3.16.1",
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.10.0",
         "react-toastify": "^9.1.2",
@@ -388,6 +391,52 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.10.6",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.6.tgz",
+      "integrity": "sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/serialize": "^1.1.1",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.1.3"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.10.7",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.7.tgz",
+      "integrity": "sha512-VLl1/2D6LOjH57Y8Vem1RoZ9haWF4jesHDGiHtKozDQuBIkJm2gimVo0I02sWCuzZtVACeixTVB4jeE8qvCBoQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/sheet": "^1.2.1",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "stylis": "4.1.3"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
@@ -401,6 +450,73 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
       "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
     },
+    "node_modules/@emotion/react": {
+      "version": "11.10.6",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.6.tgz",
+      "integrity": "sha512-6HT8jBmcSkfzO7mc+N1L9uwvOnlcGoix8Zn7srt+9ga0MjREo6lRpuVX0kzo6Jp6oTqDhREOFsygN6Ew4fEQbw==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.6",
+        "@emotion/cache": "^11.10.5",
+        "@emotion/serialize": "^1.1.1",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/unitless": "^0.8.0",
+        "@emotion/utils": "^1.2.0",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/serialize/node_modules/@emotion/unitless": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+      "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.10.6",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.6.tgz",
+      "integrity": "sha512-OXtBzOmDSJo5Q0AFemHCfl+bUueT8BIcPSxu0EGTpGk6DmI5dnhSzQANm1e1ze0YZL7TDyAyy6s/b/zmGOS3Og==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.6",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "@emotion/serialize": "^1.1.1",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@emotion/stylis": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
@@ -410,6 +526,24 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
+      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
+      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
+      "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.17.14",
@@ -855,6 +989,11 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -919,6 +1058,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/babel-plugin-styled-components": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
@@ -965,6 +1118,14 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelize": {
@@ -1032,8 +1193,22 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",
@@ -1079,6 +1254,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.344.tgz",
       "integrity": "sha512-m4HjHLGMPJddM0FZmPxZkk6whzeqK/B3zkzAB7KAopv2TkePzXQcM8aOfDS+1NOjD44lgA89yHRkNAQ/5uCQXQ==",
       "dev": true
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.17.14",
@@ -1134,6 +1317,16 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1147,6 +1340,11 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -1163,6 +1361,17 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/has-flag": {
@@ -1195,6 +1404,37 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+    },
+    "node_modules/is-core-module": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1211,6 +1451,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1222,6 +1467,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -1289,6 +1539,55 @@
       "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
       "dev": true
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -1339,6 +1638,21 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -1374,6 +1688,29 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-modal": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
+      "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+      "dependencies": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
+      }
     },
     "node_modules/react-redux": {
       "version": "8.0.5",
@@ -1490,6 +1827,30 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
       "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
     },
+    "node_modules/resolve": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "dependencies": {
+        "is-core-module": "^2.11.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/rollup": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.0.tgz",
@@ -1527,6 +1888,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
@@ -1566,6 +1935,11 @@
         "react-is": ">= 16.8.0"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -1575,6 +1949,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/to-fast-properties": {
@@ -1667,11 +2052,27 @@
         }
       }
     },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
     }
   },
   "dependencies": {
@@ -1940,6 +2341,48 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@emotion/babel-plugin": {
+      "version": "11.10.6",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.6.tgz",
+      "integrity": "sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/serialize": "^1.1.1",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.1.3"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
+      }
+    },
+    "@emotion/cache": {
+      "version": "11.10.7",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.7.tgz",
+      "integrity": "sha512-VLl1/2D6LOjH57Y8Vem1RoZ9haWF4jesHDGiHtKozDQuBIkJm2gimVo0I02sWCuzZtVACeixTVB4jeE8qvCBoQ==",
+      "requires": {
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/sheet": "^1.2.1",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "stylis": "4.1.3"
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+    },
     "@emotion/is-prop-valid": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
@@ -1953,6 +2396,58 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
       "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
     },
+    "@emotion/react": {
+      "version": "11.10.6",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.6.tgz",
+      "integrity": "sha512-6HT8jBmcSkfzO7mc+N1L9uwvOnlcGoix8Zn7srt+9ga0MjREo6lRpuVX0kzo6Jp6oTqDhREOFsygN6Ew4fEQbw==",
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.6",
+        "@emotion/cache": "^11.10.5",
+        "@emotion/serialize": "^1.1.1",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "hoist-non-react-statics": "^3.3.1"
+      }
+    },
+    "@emotion/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
+      "requires": {
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/unitless": "^0.8.0",
+        "@emotion/utils": "^1.2.0",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "@emotion/unitless": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+          "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
+        }
+      }
+    },
+    "@emotion/sheet": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+      "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
+    },
+    "@emotion/styled": {
+      "version": "11.10.6",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.6.tgz",
+      "integrity": "sha512-OXtBzOmDSJo5Q0AFemHCfl+bUueT8BIcPSxu0EGTpGk6DmI5dnhSzQANm1e1ze0YZL7TDyAyy6s/b/zmGOS3Og==",
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.10.6",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "@emotion/serialize": "^1.1.1",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
+        "@emotion/utils": "^1.2.0"
+      }
+    },
     "@emotion/stylis": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
@@ -1962,6 +2457,22 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
+      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
+      "requires": {}
+    },
+    "@emotion/utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
+      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
+      "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
     },
     "@esbuild/android-arm": {
       "version": "0.17.14",
@@ -2182,6 +2693,11 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -2237,6 +2753,16 @@
         "color-convert": "^1.9.0"
       }
     },
+    "babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      }
+    },
     "babel-plugin-styled-components": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
@@ -2265,6 +2791,11 @@
         "node-releases": "^2.0.8",
         "update-browserslist-db": "^1.0.10"
       }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camelize": {
       "version": "1.0.1",
@@ -2308,8 +2839,19 @@
     "convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      }
     },
     "css-color-keywords": {
       "version": "1.0.0",
@@ -2344,6 +2886,14 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.344.tgz",
       "integrity": "sha512-m4HjHLGMPJddM0FZmPxZkk6whzeqK/B3zkzAB7KAopv2TkePzXQcM8aOfDS+1NOjD44lgA89yHRkNAQ/5uCQXQ==",
       "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "esbuild": {
       "version": "0.17.14",
@@ -2386,12 +2936,27 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -2403,6 +2968,14 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
     },
     "has-flag": {
       "version": "3.0.0",
@@ -2429,6 +3002,28 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
       "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA=="
     },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+    },
+    "is-core-module": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2439,11 +3034,21 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+    },
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
+    },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "lodash": {
       "version": "4.17.21",
@@ -2493,6 +3098,40 @@
       "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
       "dev": true
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -2519,6 +3158,23 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
     },
     "react": {
       "version": "18.2.0",
@@ -2547,6 +3203,22 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-modal": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
+      "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+      "requires": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      }
     },
     "react-redux": {
       "version": "8.0.5",
@@ -2616,6 +3288,21 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
       "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
     },
+    "resolve": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "requires": {
+        "is-core-module": "^2.11.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
     "rollup": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.0.tgz",
@@ -2644,6 +3331,11 @@
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+    },
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -2667,6 +3359,11 @@
         "supports-color": "^5.5.0"
       }
     },
+    "stylis": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -2674,6 +3371,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -2708,11 +3410,24 @@
         "rollup": "^3.21.0"
       }
     },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,11 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@emotion/react": "^11.10.6",
+    "@emotion/styled": "^11.10.6",
     "@react-oauth/google": "^0.9.0",
     "@reduxjs/toolkit": "^1.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.8.0",
+    "react-modal": "^3.16.1",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.10.0",
     "react-toastify": "^9.1.2",

--- a/public/todo_add.svg
+++ b/public/todo_add.svg
@@ -1,0 +1,10 @@
+<svg width="35" height="35" viewBox="0 0 35 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_229_1278)">
+<path d="M20.4167 14.5833H2.91669V17.5H20.4167V14.5833ZM20.4167 8.75H2.91669V11.6667H20.4167V8.75ZM26.25 20.4167V14.5833H23.3334V20.4167H17.5V23.3333H23.3334V29.1667H26.25V23.3333H32.0834V20.4167H26.25ZM2.91669 23.3333H14.5834V20.4167H2.91669V23.3333Z" fill="#6C55FE"/>
+</g>
+<defs>
+<clipPath id="clip0_229_1278">
+<rect width="35" height="35" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,25 +1,33 @@
-import React from "react";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import { ToastContainer } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
+import React from 'react';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
-import { Root, ErrorPage, LandingPage, LoginPage, SignUpPage } from "./pages/index";
+import {
+  Root,
+  ErrorPage,
+  LandingPage,
+  LoginPage,
+  SignUpPage,
+  PersonalSchedulePage,
+} from './pages/index';
 
 const router = createBrowserRouter([
   {
-    path: "/",
+    path: '/',
     element: <Root />,
     errorElement: <ErrorPage />,
     children: [{ index: true, element: <LandingPage /> }],
   },
-  { path: "/login", element: <LoginPage /> },
-  { path: "/signup", element: <SignUpPage /> },
+  { path: '/login', element: <LoginPage /> },
+  { path: '/signup', element: <SignUpPage /> },
+  { path: '/personal', element: <PersonalSchedulePage /> },
 ]);
 
 export default function App() {
   return (
     <>
-      <ToastContainer position="top-center" style={{ width: "auto" }} />
+      <ToastContainer position="top-center" style={{ width: 'auto' }} />
       <RouterProvider router={router} />
     </>
   );

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { handleMenuToggle } from '../../store/user/user-slice';
+import {
+  HeaderContainer,
+  Logo,
+  LogoImage,
+  Title,
+  Navigation,
+  NavLink,
+  CreateButton,
+  HamburgerMenu,
+} from './Header.styles';
+
+const Header = () => {
+  const menuOpen = useSelector((state) => state.user.menuOpen);
+  const dispatch = useDispatch();
+
+  const handleMenuOpen = () => {
+    dispatch(handleMenuToggle());
+  };
+
+  return (
+    <HeaderContainer>
+      <Logo>
+        <LogoImage src="/logo.svg" alt="Logo" />
+        <Title>xERN</Title>
+      </Logo>
+      <HamburgerMenu onClick={handleMenuOpen}>
+        <i className={`fas fa-${menuOpen ? 'times' : 'bars'}`}></i>
+      </HamburgerMenu>
+      <Navigation open={menuOpen}>
+        <NavLink to="/share">공유일정 확인</NavLink>
+        <NavLink to="/personal">개인일정</NavLink>
+        <NavLink to="/community">커뮤니티</NavLink>
+        <NavLink to="/mypage">마이페이지</NavLink>
+        <CreateButton>공유 페이지 생성</CreateButton>
+      </Navigation>
+    </HeaderContainer>
+  );
+};
+
+export default Header;

--- a/src/components/Header/Header.styles.js
+++ b/src/components/Header/Header.styles.js
@@ -1,0 +1,144 @@
+import styled from 'styled-components';
+import { NavLink as RouterNavLink } from 'react-router-dom';
+
+export const HeaderContainer = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 20px;
+  margin: 2%;
+  border-radius: 100px;
+  background-color: white;
+  box-shadow: 0px 5px 50px 4px rgba(0, 0, 0, 0.15);
+
+  @media (max-width: 900px) {
+    flex-wrap: wrap;
+    padding: 0px 15px 0px 15px;
+    border-radius: 10px;
+  }
+`;
+
+export const Logo = styled.div`
+  display: flex;
+  align-items: center;
+  filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.2));
+`;
+
+export const LogoImage = styled.img`
+  height: 50px;
+`;
+
+export const Title = styled.h1`
+  margin-left: 10px;
+  font-family: 'Montserrat';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 30px;
+  line-height: 37px;
+
+  @media (max-width: 900px) {
+    font-size: 24px;
+    line-height: 30px;
+  }
+`;
+
+export const HamburgerMenu = styled.div`
+  display: none;
+
+  @media (max-width: 900px) {
+    display: block;
+    cursor: pointer;
+    font-size: 24px;
+    padding-top: 5px;
+    align-items: center;
+    justify-content: center;
+  }
+`;
+
+export const Navigation = styled.nav`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 30px;
+
+  @media (max-width: 900px) {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    margin-top: 15px;
+    width: 100%;
+    max-height: ${(props) => (props.open ? '500px' : '0')};
+    overflow: hidden;
+    transition: max-height 0.3s ease-in-out;
+  }
+`;
+
+export const NavLink = styled(RouterNavLink)`
+  margin-right: 20px;
+  text-decoration: none;
+  cursor: pointer;
+  color: #121127;
+  font-family: 'Poppins';
+  font-style: normal;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 180%;
+  opacity: 0.6;
+  transition: color 0.3s ease, text-decoration-color 0.3s ease;
+
+  &:hover {
+    color: #6c55fe;
+    font-weight: 700;
+    opacity: 1;
+    text-decoration: underline;
+    text-underline-offset: 15px;
+    text-decoration-color: #6c55fe;
+  }
+
+  &.active {
+    color: #6c55fe;
+    font-weight: 700;
+    opacity: 1;
+    text-decoration: underline;
+    text-underline-offset: 15px;
+    text-decoration-color: #6c55fe;
+  }
+
+  @media (max-width: 900px) {
+    font-size: 14px;
+    margin: 0px;
+  }
+`;
+
+export const CreateButton = styled.button`
+  padding: 13px 26px;
+  cursor: pointer;
+  color: white;
+  border-radius: 100px;
+  border-style: none;
+  background: #6c55fe;
+  box-shadow: 0px 4px 2px rgba(0, 0, 0, 0.25);
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 12px;
+  line-height: 15px;
+  text-align: center;
+  text-transform: uppercase;
+  transition: background 0.3s ease;
+
+  &:hover {
+    background: #4e3bce;
+  }
+
+  @media (max-width: 900px) {
+    width: 50%;
+    padding: 10px 20px;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    font-size: 10px;
+    line-height: 12px;
+    border-radius: 10px;
+    box-shadow: none;
+  }
+`;

--- a/src/components/PersonalTodoList/Modal/Modal.jsx
+++ b/src/components/PersonalTodoList/Modal/Modal.jsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import Modal from 'react-modal';
+
+import { useDispatch, useSelector } from 'react-redux';
+import { handleMenuToggle } from '../../../store/user/user-slice';
+import { toast } from 'react-toastify';
+
+import { ModalOverlay, ModalContainer } from './Modal.styles';
+import ModalHeader from './ModalHeader';
+import ModalBody from './ModalBody';
+import ModalFooter from './ModalFooter';
+
+Modal.setAppElement('#root');
+
+const ModalWindow = () => {
+  const [formValues, setFormValues] = useState({
+    title: '',
+    details: '',
+    startDate: '',
+    startTime: '',
+    endDate: '',
+    endTime: '',
+    repeat: 'none',
+    notification: 'none',
+  });
+
+  const today = new Date().toISOString().slice(0, 10);
+  let currentDate = today.replace(/-/g, '.');
+  currentDate =
+    currentDate.slice(0, 4) +
+    '년 ' +
+    currentDate.slice(5, 7) +
+    '월 ' +
+    currentDate.slice(8, 10) +
+    '일';
+
+  const menuOpen = useSelector((state) => state.user.menuOpen);
+  const dispatch = useDispatch();
+
+  const handleMenuOpen = () => {
+    dispatch(handleMenuToggle());
+  };
+
+  const isTimeValid = () => {
+    if (formValues.startDate === formValues.endDate) {
+      if (formValues.endTime < formValues.startTime) {
+        toast.error(
+          '종료 시간은 시작 시간보다 빠를 수 없습니다. 다시 입력해주세요.'
+        );
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const checkFieldsFilled = () => {
+    return (
+      formValues.title &&
+      formValues.details &&
+      formValues.startDate &&
+      formValues.startTime &&
+      formValues.endDate &&
+      formValues.endTime
+    );
+  };
+
+  const handleSubmit = () => {
+    // 시간 유효성 검사
+    if (!isTimeValid()) {
+      return;
+    }
+
+    // 일정 저장 로직
+
+    // 폼 초기화
+    setFormValues({
+      title: '',
+      details: '',
+      startDate: '',
+      startTime: '',
+      endDate: '',
+      endTime: '',
+      repeat: 'none',
+      notification: 'none',
+    });
+  };
+
+  return (
+    <Modal
+      isOpen={menuOpen}
+      onRequestClose={handleMenuOpen}
+      style={{
+        overlay: { background: 'transparent' },
+        content: { background: 'transparent', border: 'none' },
+      }}
+    >
+      <ModalOverlay>
+        <ModalContainer>
+          <ModalHeader
+            currentDate={currentDate}
+            handleMenuOpen={handleMenuOpen}
+          />
+          <ModalBody
+            formValues={formValues}
+            setFormValues={setFormValues}
+            today={today}
+          />
+          <ModalFooter
+            handleSubmit={handleSubmit}
+            checkFieldsFilled={checkFieldsFilled}
+          />
+        </ModalContainer>
+      </ModalOverlay>
+    </Modal>
+  );
+};
+
+export default ModalWindow;

--- a/src/components/PersonalTodoList/Modal/Modal.styles.js
+++ b/src/components/PersonalTodoList/Modal/Modal.styles.js
@@ -1,0 +1,163 @@
+import styled from 'styled-components';
+
+export const ModalOverlay = styled.div`
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+`;
+
+export const ModalContainer = styled.div`
+  background: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+  max-width: 600px;
+  height: 500px;
+  padding: 20px;
+  position: relative;
+  width: 100%;
+  font-family: 'Inter', sans-serif;
+`;
+
+export const ModalHeaderStyled = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 18px;
+  font-weight: 600;
+`;
+
+export const ModalCloseButton = styled.button`
+  background: none;
+  border: none;
+  color: #4e4e4e;
+  cursor: pointer;
+  font-size: 50px;
+`;
+
+export const ModalInputLabel = styled.label`
+  display: block;
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 15px;
+`;
+
+export const ModalTitle = styled.input`
+  border: none;
+  border-bottom: 2px solid black;
+  font-size: 16px;
+  margin-bottom: 20px;
+  width: 100%;
+  height: 40px;
+
+  &:focus {
+    outline: none;
+  }
+
+  &::placeholder {
+    font-family: 'Inter', sans-serif;
+  }
+`;
+
+export const ModalInput = styled.input`
+  display: block;
+  border: none;
+  border-radius: 4px;
+  background: #f4f6fc;
+  font-size: 14px;
+  margin-bottom: 20px;
+  width: 100%;
+  height: 35px;
+  font-family: 'Inter', sans-serif;
+`;
+
+export const ModalInputGap = styled.div`
+  margin-right: 10px;
+`;
+
+export const ModalTextarea = styled.textarea`
+  border: none;
+  background: #f4f6fc;
+  display: block;
+  font-size: 16px;
+  margin-bottom: 20px;
+  resize: none;
+  width: 100%;
+
+  &::placeholder {
+    font-family: 'Inter', sans-serif;
+  }
+`;
+
+export const ModalDateRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const ModalDateColumn = styled.div`
+  display: flex;
+  width: 45%;
+  border: none;
+`;
+
+export const ModalSelectRow = styled.div`
+  display: flex;
+  justify-content: start;
+  margin-bottom: 50px;
+`;
+
+export const SelectContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+`;
+
+export const Select = styled.select`
+  width: 200px;
+  margin-right: 20px;
+  padding: 6px 12px;
+  background-color: white;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+  font-size: 1rem;
+  color: #495057;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  &:focus {
+    border-color: #80bdff;
+    outline: 0;
+    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+  }
+`;
+
+export const SelectLabel = styled.label`
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 10px;
+`;
+
+export const SaveButton = styled.button`
+  width: 150px;
+  background: ${({ disabled }) => (disabled ? '#ccc' : '#6c55fe')};
+  border: none;
+  border-radius: 4px;
+  color: #ffffff;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  font-family: 'Inter', sans-serif;
+  font-size: 16px;
+  font-weight: 600;
+  padding: 10px 20px;
+  position: absolute;
+  right: 20px;
+  opacity: ${({ disabled }) => (disabled ? 0.6 : 1)};
+  pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
+  transition: background 0.3s, opacity 0.3s;
+
+  &:hover {
+    background: ${({ disabled }) => (disabled ? '#ccc' : '#A495FF')};
+  }
+`;

--- a/src/components/PersonalTodoList/Modal/ModalBody.jsx
+++ b/src/components/PersonalTodoList/Modal/ModalBody.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import {
+  ModalInputLabel,
+  ModalTitle,
+  ModalInput,
+  ModalInputGap,
+  ModalTextarea,
+  ModalDateRow,
+  ModalDateColumn,
+  ModalSelectRow,
+  SelectContainer,
+  Select,
+  SelectLabel,
+} from './Modal.styles';
+
+const ModalBody = ({ formValues, setFormValues, today }) => {
+  return (
+    <>
+      <ModalTitle
+        id="title"
+        type="text"
+        placeholder="일정 제목"
+        value={formValues.title}
+        onChange={(e) =>
+          setFormValues({ ...formValues, title: e.target.value })
+        }
+      />
+      <ModalTextarea
+        id="details"
+        rows="5"
+        placeholder="상세 내용"
+        value={formValues.details}
+        onChange={(e) =>
+          setFormValues({ ...formValues, details: e.target.value })
+        }
+      />
+      <ModalInputLabel htmlFor="date-time">날짜 및 시간</ModalInputLabel>
+      <ModalDateRow>
+        <ModalDateColumn>
+          <ModalInput
+            type="date"
+            min={today}
+            value={formValues.startDate}
+            onChange={(e) =>
+              setFormValues({ ...formValues, startDate: e.target.value })
+            }
+          />
+          <ModalInputGap />
+          <ModalInput
+            type="time"
+            value={formValues.startTime}
+            onChange={(e) =>
+              setFormValues({ ...formValues, startTime: e.target.value })
+            }
+          />
+        </ModalDateColumn>
+        ~
+        <ModalDateColumn>
+          <ModalInput
+            type="date"
+            min={formValues.startDate || today}
+            value={formValues.endDate}
+            onChange={(e) =>
+              setFormValues({ ...formValues, endDate: e.target.value })
+            }
+          />
+          <ModalInputGap />
+          <ModalInput
+            type="time"
+            value={formValues.endTime}
+            onChange={(e) =>
+              setFormValues({ ...formValues, endTime: e.target.value })
+            }
+          />
+        </ModalDateColumn>
+      </ModalDateRow>
+      <ModalSelectRow>
+        <SelectContainer>
+          <SelectLabel htmlFor="repeat">반복 여부</SelectLabel>
+          <Select
+            value={formValues.repeat}
+            onChange={(e) =>
+              setFormValues({ ...formValues, repeat: e.target.value })
+            }
+            id="repeat"
+          >
+            <option value="none">반복 안함</option>
+            <option value="daily">매일</option>
+            <option value="weekly">매주</option>
+            <option value="monthly">매월</option>
+            <option value="yearly">매년</option>
+          </Select>
+        </SelectContainer>
+        <SelectContainer>
+          <SelectLabel htmlFor="notification">알림 기능</SelectLabel>
+          <Select
+            value={formValues.notification}
+            onChange={(e) =>
+              setFormValues({ ...formValues, notification: e.target.value })
+            }
+            id="notification"
+          >
+            <option value="none">알림 안함</option>
+            <option value="5">5분</option>
+            <option value="15">15분</option>
+            <option value="30">30분</option>
+            <option value="60">1분</option>
+            <option value="120">2분</option>
+          </Select>
+        </SelectContainer>
+      </ModalSelectRow>
+    </>
+  );
+};
+
+export default ModalBody;

--- a/src/components/PersonalTodoList/Modal/ModalFooter.jsx
+++ b/src/components/PersonalTodoList/Modal/ModalFooter.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { SaveButton } from './Modal.styles';
+
+const ModalFooter = ({ handleSubmit, checkFieldsFilled }) => (
+  <SaveButton onClick={handleSubmit} disabled={!checkFieldsFilled()}>
+    저장하기
+  </SaveButton>
+);
+
+export default ModalFooter;

--- a/src/components/PersonalTodoList/Modal/ModalHeader.jsx
+++ b/src/components/PersonalTodoList/Modal/ModalHeader.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ModalHeaderStyled, ModalCloseButton } from './Modal.styles';
+
+const ModalHeader = ({ currentDate, handleMenuOpen }) => (
+  <ModalHeaderStyled>
+    <span>{currentDate}</span>
+    <ModalCloseButton onClick={handleMenuOpen}>×</ModalCloseButton>
+  </ModalHeaderStyled>
+);
+
+export default ModalHeader;

--- a/src/components/PersonalTodoList/PersonalTodoList.jsx
+++ b/src/components/PersonalTodoList/PersonalTodoList.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { handleMenuToggle } from '../../store/user/user-slice';
+import ModalWindow from './Modal/Modal';
+import {
+  TodoContainer,
+  TodoHeader,
+  TodoTabs,
+  TodoTab,
+  AddEventButton,
+  TodoBody,
+  TodoTitle,
+  TodoSubtitle,
+  TodoList,
+  TodoItem,
+} from './PersonalTodoList.styles';
+
+const PersonalTodoList = () => {
+  const [selectedTab, setSelectedTab] = useState(false);
+  const menuOpen = useSelector((state) => state.user.menuOpen);
+  const dispatch = useDispatch();
+
+  const handleMenuOpen = () => {
+    dispatch(handleMenuToggle());
+  };
+
+  return (
+    <>
+      <TodoContainer>
+        <TodoHeader>
+          <TodoTabs>
+            <TodoTab
+              selected={selectedTab === false}
+              onClick={() => setSelectedTab(false)}
+            >
+              오늘 할 일
+            </TodoTab>
+            <TodoTab
+              selected={selectedTab === true}
+              onClick={() => setSelectedTab(true)}
+            >
+              예정
+            </TodoTab>
+          </TodoTabs>
+        </TodoHeader>
+        <TodoBody>
+          <TodoTitle>
+            오늘의 할 일
+            <AddEventButton onClick={handleMenuOpen}>
+              <img src="/todo_add.svg" alt="Add-icon" />
+              일정추가
+            </AddEventButton>
+          </TodoTitle>
+          <TodoSubtitle>하루동안의 할 일을 관리합니다.</TodoSubtitle>
+          <TodoList>
+            <TodoItem>Item 1</TodoItem>
+            <TodoItem>Item 2</TodoItem>
+          </TodoList>
+        </TodoBody>
+      </TodoContainer>
+      {menuOpen && <ModalWindow />}
+    </>
+  );
+};
+
+export default PersonalTodoList;

--- a/src/components/PersonalTodoList/PersonalTodoList.jsx
+++ b/src/components/PersonalTodoList/PersonalTodoList.jsx
@@ -11,8 +11,7 @@ import {
   TodoBody,
   TodoTitle,
   TodoSubtitle,
-  TodoList,
-  TodoItem,
+  TodoButton,
 } from './PersonalTodoList.styles';
 
 const PersonalTodoList = () => {
@@ -52,10 +51,10 @@ const PersonalTodoList = () => {
             </AddEventButton>
           </TodoTitle>
           <TodoSubtitle>하루동안의 할 일을 관리합니다.</TodoSubtitle>
-          <TodoList>
-            <TodoItem>Item 1</TodoItem>
-            <TodoItem>Item 2</TodoItem>
-          </TodoList>
+          <TodoButton onClick={handleMenuOpen}>
+            아직 추가된 일정이 없습니다! <br />할 일을 추가하여 하루동안 할 일을
+            관리해보세요.
+          </TodoButton>
         </TodoBody>
       </TodoContainer>
       {menuOpen && <ModalWindow />}

--- a/src/components/PersonalTodoList/PersonalTodoList.styles.js
+++ b/src/components/PersonalTodoList/PersonalTodoList.styles.js
@@ -1,0 +1,113 @@
+import styled from 'styled-components';
+
+export const TodoContainer = styled.div`
+  width: 40%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin-left: 20px;
+  height: 450px;
+  min-width: 450px;
+  max-width: 450px;
+`;
+
+export const TodoHeader = styled.div`
+  display: flex;
+  margin-bottom: 20px;
+`;
+
+export const TodoTabs = styled.div`
+  min-width: 350px;
+  max-width: 350px;
+  display: flex;
+  width: 100%;
+  height: 33px;
+  border: 2px solid #e5e5e5;
+  border-radius: 5px;
+`;
+
+export const TodoTab = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 50%;
+  border-radius: 5px;
+  background: ${(props) => (props.selected ? '#A495FF' : 'none')};
+  border: none;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  color: ${(props) => (props.selected ? 'white' : '#121127')};
+  opacity: ${(props) => (props.selected ? '1' : '0.6')};
+  transition: opacity 0.3s ease, background 0.3s ease, color 0.3s ease;
+
+  &:hover {
+    opacity: 1;
+    background: #a495ff;
+    color: white;
+    border-radius: 5px;
+  }
+`;
+
+export const AddEventButton = styled.button`
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  background: none;
+  border: none;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  color: #6c55fe;
+  transition: opacity 0.3s ease;
+
+  &:hover {
+    opacity: 0.7;
+  }
+`;
+
+export const TodoBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  background-color: rgba(230, 233, 236, 0.4);
+  height: 400px;
+  min-width: 450px;
+  max-width: 450px;
+  border-radius: 48px;
+  // box-shadow: 0px 5px 50px 4px rgba(0, 0, 0, 0.15);
+  padding: 20px;
+`;
+
+export const TodoTitle = styled.h2`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 24px;
+  color: #313131;
+  margin-top: 0px;
+  margin-bottom: 0px;
+`;
+
+export const TodoSubtitle = styled.h3`
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 15px;
+  color: #2f2f2f;
+  margin-bottom: 20px;
+  color: #777;
+  padding: 0;
+  margin: 0;
+`;
+
+export const TodoList = styled.ul``;
+
+export const TodoItem = styled.li`
+  font-size: 18px;
+  margin-bottom: 10px;
+`;

--- a/src/components/PersonalTodoList/PersonalTodoList.styles.js
+++ b/src/components/PersonalTodoList/PersonalTodoList.styles.js
@@ -10,6 +10,7 @@ export const TodoContainer = styled.div`
   height: 450px;
   min-width: 450px;
   max-width: 450px;
+  font-family: 'Inter';
 `;
 
 export const TodoHeader = styled.div`
@@ -105,9 +106,24 @@ export const TodoSubtitle = styled.h3`
   margin: 0;
 `;
 
-export const TodoList = styled.ul``;
+export const TodoButton = styled.button`
+  width: 100%;
+  height: 60%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: white;
+  border-radius: 10px;
+  border: 1px solid #6c55fe;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 16px;
+  cursor: pointer;
+  color: #30374f;
+  margin-top: 20px;
+  transition: opacity 0.3s ease;
 
-export const TodoItem = styled.li`
-  font-size: 18px;
-  margin-bottom: 10px;
+  &:hover {
+    opacity: 0.7;
+  }
 `;

--- a/src/pages/PersonalSchedulePage.jsx
+++ b/src/pages/PersonalSchedulePage.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Header from '../components/Header/Header';
+import PersonalTodoList from '../components/PersonalTodoList/PersonalTodoList';
+import styled from 'styled-components';
+
+const MainContainer = styled.main`
+  display: flex;
+  justify-content: space-between;
+  margin: 0px 60px 0px 40px;
+  font-family: 'Inter', sans-serif;
+`;
+
+// 임시 달력 컨테이너
+const CalendarContainer = styled.div`
+  width: 60%;
+  background-color: black;
+  height: 500px;
+  min-width: 850px;
+  max-width: 850px;
+`;
+
+const PersonalSchedulePage = () => {
+  return (
+    <>
+      <Header />
+      <MainContainer>
+        <CalendarContainer />
+        <PersonalTodoList />
+      </MainContainer>
+    </>
+  );
+};
+
+export default PersonalSchedulePage;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,7 +1,15 @@
-import ErrorPage from "./ErrorPage";
-import LandingPage from "./LandingPage";
-import LoginPage from "./LoginPage";
-import Root from "./Root";
-import SignUpPage from "./SignUpPage";
+import ErrorPage from './ErrorPage';
+import LandingPage from './LandingPage';
+import LoginPage from './LoginPage';
+import Root from './Root';
+import SignUpPage from './SignUpPage';
+import PersonalSchedulePage from './PersonalSchedulePage';
 
-export { ErrorPage, LandingPage, LoginPage, Root, SignUpPage };
+export {
+  ErrorPage,
+  LandingPage,
+  LoginPage,
+  Root,
+  SignUpPage,
+  PersonalSchedulePage,
+};

--- a/src/store/user/user-slice.jsx
+++ b/src/store/user/user-slice.jsx
@@ -1,39 +1,43 @@
-import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { toast } from "react-toastify";
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { toast } from 'react-toastify';
 
 const initialState = {
   user: {},
   isLoading: false,
+  menuOpen: false, // 메뉴 or 모달 같은 것들을 토글하기 위한 상태
 };
 
-export const signup = createAsyncThunk("user/signup", async (user, thunkAPI) => {
-  try {
-    const response = await fetch(`/back/api/auth/join`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(user),
-    });
+export const signup = createAsyncThunk(
+  'user/signup',
+  async (user, thunkAPI) => {
+    try {
+      const response = await fetch(`/back/api/auth/join`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(user),
+      });
 
-    if (!response.ok) {
-      throw await response.json();
+      if (!response.ok) {
+        throw await response.json();
+      }
+
+      const data = await response.json();
+      console.log(data);
+      return data;
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error.message);
     }
-
-    const data = await response.json();
-    console.log(data);
-    return data;
-  } catch (error) {
-    return thunkAPI.rejectWithValue(error.message);
   }
-});
+);
 
-export const login = createAsyncThunk("user/login", async (user, thunkAPI) => {
+export const login = createAsyncThunk('user/login', async (user, thunkAPI) => {
   try {
     const response = await fetch(`/back/api/auth/login`, {
-      method: "POST",
+      method: 'POST',
       headers: {
-        "Content-Type": "application/json",
+        'Content-Type': 'application/json',
         authorization: `Bearer ${thunkAPI.getState().user.user.token}`,
       },
       body: JSON.stringify(user),
@@ -50,33 +54,40 @@ export const login = createAsyncThunk("user/login", async (user, thunkAPI) => {
   }
 });
 
-export const naverLogin = createAsyncThunk("user/naverLogin", async (naverInfo, thunkAPI) => {
-  try {
-    const response = await fetch("/back/api/auth/naver", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(naverInfo),
-    });
+export const naverLogin = createAsyncThunk(
+  'user/naverLogin',
+  async (naverInfo, thunkAPI) => {
+    try {
+      const response = await fetch('/back/api/auth/naver', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(naverInfo),
+      });
 
-    if (!response.ok) {
-      throw await response.json();
+      if (!response.ok) {
+        throw await response.json();
+      }
+
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error.message);
     }
-
-    const data = await response.json();
-    return data;
-  } catch (error) {
-    return thunkAPI.rejectWithValue(error.message);
   }
-});
+);
 
 const userSlice = createSlice({
-  name: "user",
+  name: 'user',
   initialState,
   reducers: {
     logout: (state) => {
-      (state.user = null), toast.success("로그아웃에 성공하셨습니다");
+      (state.user = null), toast.success('로그아웃에 성공하셨습니다');
+    },
+
+    handleMenuToggle: (state) => {
+      state.menuOpen = !state.menuOpen;
     },
   },
   extraReducers: (builder) => {
@@ -125,6 +136,6 @@ const userSlice = createSlice({
   },
 });
 
-export const { logout } = userSlice.actions;
+export const { logout, handleMenuToggle } = userSlice.actions;
 
 export default userSlice.reducer;


### PR DESCRIPTION
- [ ] #8 
resolved: #8 

# 설명
- 개인 일정 페이지 (PersonalSchedulePage) 추가
- 개인 일정 페이지에 삽입될 컴포넌트 (Header, PersonalTodoList, Modal) 추가
- PersonalSchedulePage.jsx에 임시로 <CalendarContainer /> 달력 부분 추가

# 테스트
- N/A

# Demo
[개인 일정 페이지 (PersonalSchedulePage )]
![1](https://user-images.githubusercontent.com/71217361/235067508-f462bf2a-ed10-472b-a55e-d73868b6580a.png)

